### PR TITLE
Urgent typo fix suggestion

### DIFF
--- a/principal_component_analysis.ipynb
+++ b/principal_component_analysis.ipynb
@@ -215,7 +215,7 @@
    "source": [
     "Often, the desired goal is to reduce the dimensions of a $d$-dimensional dataset by projecting it onto a $(k)$-dimensional subspace (where $k\\;<\\;d$) in order to increase the computational efficiency while retaining most of the information. An important question is \"what is the size of $k$ that represents the data 'well'?\"\n",
     "\n",
-    "Later, we will compute eigenvectors (the principal components) of a dataset and collect them in a projection matrix. Each of those eigenvectors is associated with an eigenvalue which can be interpreted as the \"length\" or \"magnitude\" of the corresponding eigenvector. If some eigenvalues have a significantly larger magnitude than others that the reduction of the dataset via PCA onto a smaller dimensional subspace by dropping the \"less informative\" eigenpairs is reasonable.\n"
+    "Later, we will compute eigenvectors (the principal components) of a dataset and collect them in a projection matrix. Each of those eigenvectors is associated with an eigenvalue which can be interpreted as the \"length\" or \"magnitude\" of the corresponding eigenvector. If some eigenvalues have a significantly larger magnitude than others then the reduction of the dataset via PCA onto a smaller dimensional subspace by dropping the \"less informative\" eigenpairs is reasonable.\n"
    ]
   },
   {


### PR DESCRIPTION
There is a typo in the "Introduction", section, under heading "PCA and Dimensionality Reduction", in the last sentence.

CURRENT TEXT:
"larger magnitude than others THAT the reduction..."

SUGGESTED CORRECTION:
"larger magnitude than others THEN the reduction..."﻿